### PR TITLE
refac: added constructor parameter validation to RWAOracle Contract

### DIFF
--- a/stellar-contracts/rwa-oracle/src/common/error.rs
+++ b/stellar-contracts/rwa-oracle/src/common/error.rs
@@ -33,4 +33,10 @@ pub enum Error {
 
     /// Contract is paused
     Paused = 9,
+
+    /// Invalid decimals parameter
+    InvalidDecimals = 10,
+
+    /// Invalid resolution parameter
+    InvalidResolution = 11,
 }

--- a/stellar-contracts/rwa-oracle/src/common/types.rs
+++ b/stellar-contracts/rwa-oracle/src/common/types.rs
@@ -22,6 +22,11 @@ pub const MAX_TIMESTAMP_DRIFT_SECONDS: u64 = 300;
 // Default max staleness: 24 hours
 pub const DEFAULT_MAX_STALENESS: u64 = 86_400;
 
+// Parameters validation bounds
+pub const MIN_DECIMALS: u32 = 2;
+pub const MAX_DECIMALS: u32 = 18;
+pub const MIN_RESOLUTION: u32 = 1;
+
 #[contracttype]
 pub enum DataKey {
     Prices(Asset),

--- a/stellar-contracts/rwa-oracle/src/contract.rs
+++ b/stellar-contracts/rwa-oracle/src/contract.rs
@@ -7,7 +7,7 @@ use crate::common::error::Error;
 use crate::common::storage::RWAOracleStorage;
 use crate::common::types::{
     DataKey, MAX_PRICE_HISTORY, MAX_TIMESTAMP_DRIFT_SECONDS, PERSISTENT_BUMP_AMOUNT,
-    PERSISTENT_LIFETIME_THRESHOLD,
+    PERSISTENT_LIFETIME_THRESHOLD, MIN_DECIMALS, MAX_DECIMALS, MIN_RESOLUTION,
 };
 use crate::rwa::types::{RWAAssetType, RWAMetadata, TokenizationInfo};
 use crate::sep40::{IsSep40, IsSep40Admin};
@@ -30,6 +30,14 @@ impl RWAOracle {
         decimals: u32,
         resolution: u32,
     ) -> Result<(), Error> {
+        // Validate parameters before saving any state
+        if decimals < MIN_DECIMALS || decimals > MAX_DECIMALS {
+            panic_with_error!(env, Error::InvalidDecimals);
+        }
+        if resolution < MIN_RESOLUTION {
+            panic_with_error!(env, Error::InvalidResolution);
+        }
+
         Admin::set_admin(env, &admin);
         let oracle = RWAOracleStorage::new(env, assets.clone(), base, decimals, resolution);
         RWAOracleStorage::set(env, &oracle);

--- a/stellar-contracts/rwa-oracle/src/test/mod.rs
+++ b/stellar-contracts/rwa-oracle/src/test/mod.rs
@@ -79,6 +79,81 @@ fn test_rwa_oracle_initialization() {
     assert_eq!(oracle.max_staleness(), 86_400); // default 24h
 }
 
+// validations
+
+#[test]
+#[should_panic(expected = "Error(Contract, #10)")]
+fn test_decimals_zero_rejected() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let admin = Address::generate(&e);
+    let asset = Asset::Other(Symbol::new(&e, "TEST"));
+    let assets = Vec::from_array(&e, [asset.clone()]);
+
+    // decimal 0 should panic
+    e.register(RWAOracle, (admin, assets, asset, 0u32, 300u32));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #10)")]
+fn test_decimals_one_rejected() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let admin = Address::generate(&e);
+    let asset = Asset::Other(Symbol::new(&e, "TEST"));
+    let assets = Vec::from_array(&e, [asset.clone()]);
+
+    // decimals = 1 should panic
+    e.register(RWAOracle, (admin, assets, asset, 1u32, 300u32));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #10)")]
+fn test_decimals_above_max_rejected() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let admin = Address::generate(&e);
+    let asset = Asset::Other(Symbol::new(&e, "TEST"));
+    let assets = Vec::from_array(&e, [asset.clone()]);
+
+    // decimals > MAX_DECIMALS should panic
+    e.register(RWAOracle, (admin, assets, asset, 19u32, 300u32));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #11)")]
+fn test_resolution_zero_rejected() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let admin = Address::generate(&e);
+    let asset = Asset::Other(Symbol::new(&e, "TEST"));
+    let assets = Vec::from_array(&e, [asset.clone()]);
+
+    // resolution = 0 should panic
+    e.register(RWAOracle, (admin, assets, asset, 8u32, 0u32));
+}
+
+#[test]
+fn test_valid_params_accepted() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let admin = Address::generate(&e);
+    let asset = Asset::Other(Symbol::new(&e, "TEST"));
+    let assets = Vec::from_array(&e, [asset.clone()]);
+
+    // should succeed with valid parameters
+    let contract_id = e.register(RWAOracle, (admin, assets.clone(), asset.clone(), 8u32, 60u32));
+    let client = RWAOracleClient::new(&e, &contract_id);
+    assert_eq!(client.decimals(), 8);
+    assert_eq!(client.resolution(), 60);
+}
+
+
 // ==================== RWA Metadata Tests ====================
 
 #[test]


### PR DESCRIPTION
## Description
This PR adds validation for constructor parameters in the RWAOracle contract to prevent deployment with invalid values that could break price calculations or oracle functionality.

### Changes Made
- Added `InvalidDecimals` (10) and `InvalidResolution` (11) error variants
- Added validation constants: `MIN_DECIMALS = 2`, `MAX_DECIMALS = 18`, `MIN_RESOLUTION = 1`
- Implemented constructor validation:
  - Decimals must be between 2 and 18 inclusive
  - Resolution must be at least 1
- Added comprehensive test coverage for all validation scenarios

### Testing
- ✅ `test_decimals_zero_rejected` - panics with `InvalidDecimals`
- ✅ `test_decimals_one_rejected` - panics with `InvalidDecimals`
- ✅ `test_decimals_above_max_rejected` - panics with `InvalidDecimals`
- ✅ `test_resolution_zero_rejected` - panics with `InvalidResolution`
- ✅ `test_valid_params_accepted` - successfully initializes with valid params
- All existing tests continue to pass

```bash

running 46 tests
test test::test_decimals_zero_rejected - should panic ... ok
test test::test_decimals_one_rejected - should panic ... ok
test test::test_decimals_above_max_rejected - should panic ... ok
test test::test_future_timestamp_rejected - should panic ... ok
test test::test_error_handling ... ok
test test::test_different_assets_independent_timestamps ... ok
test test::test_instance_ttl_extended_on_price_update ... ok
test test::test_asset_type_always_synced_with_metadata ... ok
test test::test_max_staleness_default ... ok
test test::test_metadata_accepted_after_add_assets ... ok
test test::test_get_all_rwa_assets ... ok
test test::test_metadata_accepted_for_registered_asset ... ok
test test::test_metadata_asset_id_mismatch_rejected - should panic ... ok
test test::test_metadata_asset_id_match_accepted ... ok
test test::test_metadata_mismatch_no_state_change ... ok
test test::test_metadata_consistency_after_set ... ok
test test::test_metadata_rejected_for_unregistered_asset - should panic ... ok
test test::test_min_positive_price_accepted ... ok
test test::test_negative_price_rejected - should panic ... ok
test test::test_newer_timestamp_accepted ... ok
test test::test_old_timestamp_rejected - should panic ... ok
test test::test_only_admin_can_pause - should panic ... ok
test test::test_only_admin_can_unpause - should panic ... ok
test test::test_pause_allows_read_operations ... ok
test test::test_pause_blocks_add_assets - should panic ... ok
test test::test_pause_blocks_set_asset_price - should panic ... ok
test test::test_persistent_ttl_extended_on_price_update ... ok
test test::test_positive_price_accepted ... ok
test test::test_metadata_valuation_methods ... ok
test test::test_price_feed_compatibility ... ok
test test::test_metadata_asset_types ... ok
test test::test_resolution_zero_rejected - should panic ... ok
test test::test_rwa_oracle_initialization ... ok
test test::test_history_under_limit_not_pruned has been running for over 60 seconds
test test::test_same_timestamp_rejected - should panic ... ok
test test::test_set_max_staleness ... ok
test test::test_set_rwa_metadata ... ok
test test::test_timestamp_within_drift_accepted ... ok
test test::test_ttl_extended_on_add_assets ... ok
test test::test_ttl_extended_on_metadata_update ... ok
test test::test_unpause_allows_set_asset_price ... ok
test test::test_update_tokenization_info ... ok
test test::test_valid_params_accepted ... ok
test test::test_zero_price_rejected - should panic ... ok
test test::test_price_history_pruning has been running for over 60 seconds
test test::test_pruning_per_asset_independent has been running for over 60 seconds
test test::test_history_under_limit_not_pruned ... ok
test test::test_price_history_pruning ... ok
test test::test_pruning_per_asset_independent ... ok

test result: ok. 46 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 481.95s
```

Closes #2