### PR TITLE
feat: Implement enforce pause check consistently across all write functions

### DIFF
--- a/stellar-contracts/rwa-oracle/src/admin/mod.rs
+++ b/stellar-contracts/rwa-oracle/src/admin/mod.rs
@@ -37,6 +37,7 @@ impl Admin {
 
     /// Set the maximum acceptable age (in seconds) for price data
     pub fn set_max_staleness(env: &Env, max_seconds: u64) {
+        Self::require_not_paused(env);
         Self::require_admin(env);
         let mut state = RWAOracleStorage::get(env);
         state.max_staleness = max_seconds;

--- a/stellar-contracts/rwa-oracle/src/contract.rs
+++ b/stellar-contracts/rwa-oracle/src/contract.rs
@@ -99,6 +99,7 @@ impl RWAOracle {
         asset_id: Symbol,
         metadata: RWAMetadata,
     ) -> Result<(), Error> {
+        Admin::require_not_paused(env);
         Admin::require_admin(env);
         if metadata.asset_id != asset_id {
             panic_with_error!(env, Error::InvalidMetadata);
@@ -139,6 +140,7 @@ impl RWAOracle {
         asset_id: Symbol,
         tokenization_info: TokenizationInfo,
     ) -> Result<(), Error> {
+        Admin::require_not_paused(env);
         Admin::require_admin(env);
         let mut state = RWAOracleStorage::get(env);
 

--- a/stellar-contracts/rwa-oracle/src/test/mod.rs
+++ b/stellar-contracts/rwa-oracle/src/test/mod.rs
@@ -1076,6 +1076,62 @@ fn test_only_admin_can_unpause() {
     oracle2.unpause();
 }
 
+// ==================== RWA Admin Pause Tests ====================
+
+#[test]
+#[should_panic(expected = "Error(Contract, #9)")]
+fn test_pause_blocks_set_rwa_metadata() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let oracle = create_rwa_oracle_contract(&e);
+    let asset_id = Symbol::new(&e, "NVDA");
+    let metadata = create_test_metadata(&e, asset_id.clone());
+
+    oracle.pause();
+
+    oracle.set_rwa_metadata(&asset_id, &metadata);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #9)")]
+fn test_pause_blocks_update_tokenization_info() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let oracle = create_rwa_oracle_contract(&e);
+    let asset_id = Symbol::new(&e, "NVDA");
+
+    // First set metadata so update can work
+    let metadata = create_test_metadata(&e, asset_id.clone());
+    oracle.set_rwa_metadata(&asset_id, &metadata);
+
+    // Now pause and try to update
+    oracle.pause();
+
+    let new_tokenization = TokenizationInfo {
+        token_contract: Some(Address::generate(&e)),
+        total_supply: Some(2_000_000_000_000),
+        underlying_asset_id: Some(String::from_str(&e, "US Treasury Bond 2025")),
+        tokenization_date: Some(1_800_000_000),
+    };
+
+    oracle.update_tokenization_info(&asset_id, &new_tokenization);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #9)")]
+fn test_pause_blocks_set_max_staleness() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let oracle = create_rwa_oracle_contract(&e);
+
+    oracle.pause();
+
+    oracle.set_max_staleness(&3600u64);
+}
+
 // ==================== TTL Extension Tests ====================
 
 #[test]


### PR DESCRIPTION
Closes #31 
# PR: Enforce Pause Check Consistently Across All Write Functions

## Summary
This PR addresses a security vulnerability where the pause mechanism was inconsistently applied to write functions in the RWA Oracle contract. When the contract was paused, an admin could still modify metadata and staleness settings, which defeats the purpose of the pause mechanism.

## Problem
The pause check (`Admin::require_not_paused`) was only applied to two write functions (`add_assets` and `set_asset_price`), but three other write functions bypassed it entirely:

| Function | File | Has Pause Check |
|----------|------|-----------------|
| add_assets | contract.rs | ✓ Yes |
| set_asset_price | contract.rs | ✓ Yes |
| set_rwa_metadata | contract.rs | ✗ No (MISSING) |
| update_tokenization_info | contract.rs | ✗ No (MISSING) |
| set_max_staleness | admin/mod.rs | ✗ No (MISSING) |

### Security Risk
- If an oracle manipulation incident occurs, an attacker with a compromised key could still:
  - Reset `max_staleness` to 0 (making all prices appear stale)
  - Alter metadata to obscure evidence
  - Modify tokenization settings

## Solution
Added `Admin::require_not_paused(env)` as the **first line** in all three missing functions, ensuring fail-fast behavior before any admin authorization check.

## Changes

### Files Modified

#### 1. `stellar-contracts/rwa-oracle/src/contract.rs`
```rust
// set_rwa_metadata function - Added pause check
pub fn set_rwa_metadata(...) -> Result<(), Error> {
    Admin::require_not_paused(env);  // ADDED: First line
    Admin::require_admin(env);
    // ... rest unchanged
}

// update_tokenization_info function - Added pause check
pub fn update_tokenization_info(...) -> Result<(), Error> {
    Admin::require_not_paused(env);  // ADDED: First line
    Admin::require_admin(env);
    // ... rest unchanged
}
```

#### 2. `stellar-contracts/rwa-oracle/src/admin/mod.rs`
```rust
// set_max_staleness function - Added pause check
pub fn set_max_staleness(env: &Env, max_seconds: u64) {
    Self::require_not_paused(env);  // ADDED: First line
    Self::require_admin(env);
    // ... rest unchanged
}
```

#### 3. `stellar-contracts/rwa-oracle/src/test/mod.rs`
Added three new unit tests:
- `test_pause_blocks_set_rwa_metadata` - Verifies pause blocks metadata changes
- `test_pause_blocks_update_tokenization_info` - Verifies pause blocks tokenization updates
- `test_pause_blocks_set_max_staleness` - Verifies pause blocks staleness configuration

All tests expect `Error(Contract, #9)` (Paused error).

## Testing
Run tests with:
```bash
cd stellar-contracts
cargo test --package rwa-oracle
```

### New Test Cases
| Test Name | Scenario | Expected Result |
|-----------|----------|-----------------|
| test_pause_blocks_set_rwa_metadata | Pause contract, try to set metadata | Panic with Error(Contract, #9) |
| test_pause_blocks_update_tokenization_info | Pause contract, try to update tokenization | Panic with Error(Contract, #9) |
| test_pause_blocks_set_max_staleness | Pause contract, try to set staleness | Panic with Error(Contract, #9) |

## Acceptance Criteria
- [x] `set_rwa_metadata` calls `Admin::require_not_paused(env)` before `Admin::require_admin(env)`
- [x] `update_tokenization_info` calls `Admin::require_not_paused(env)` before `Admin::require_admin(env)`
- [x] `set_max_staleness` calls `Admin::require_not_paused(env)` before `Self::require_admin(env)`
- [x] All 3 required tests pass
- [x] All existing tests still pass

## Security Considerations
- The pause check is placed **before** the admin authorization check (fail-fast pattern)
- No authorization is performed if the contract is paused, reducing unnecessary computation
- Consistent behavior across all write functions eliminates potential confusion for future contributors

## Impact
This is a **security hardening** change that improves the robustness of the pause mechanism without changing any public API or existing behavior for non-paused states.
