### PR TITLE
refactor(rwa-oracle): remove dead code in set_rwa_metadata asset existence check

### DIFF
--- a/stellar-contracts/rwa-oracle/src/contract.rs
+++ b/stellar-contracts/rwa-oracle/src/contract.rs
@@ -105,20 +105,9 @@ impl RWAOracle {
         }
         let mut state = RWAOracleStorage::get(env);
 
-        // Verify asset is registered
         let asset = Asset::Other(asset_id.clone());
-        let asset_exists = state.assets.iter().any(|a| match a {
-            Asset::Other(sym) => sym == asset_id,
-            Asset::Stellar(addr) => {
-                if let Asset::Stellar(check_addr) = &asset {
-                    addr == *check_addr
-                } else {
-                    false
-                }
-            }
-        });
 
-        if !asset_exists {
+        if !state.assets.contains(&asset) {
             panic_with_error!(env, Error::AssetNotRegistered);
         }
 

--- a/stellar-contracts/rwa-oracle/src/test/mod.rs
+++ b/stellar-contracts/rwa-oracle/src/test/mod.rs
@@ -351,6 +351,29 @@ fn test_metadata_consistency_after_set() {
     assert_eq!(retrieved.asset_id, asset_id);
 }
 
+#[test]
+fn test_set_rwa_metadata_registered_asset_succeeds() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let oracle = create_rwa_oracle_contract(&e);
+    let asset_id = Symbol::new(&e, "NVDA");
+    let metadata = create_test_metadata(&e, asset_id.clone());
+    oracle.set_rwa_metadata(&asset_id, &metadata);
+    let stored = oracle.get_rwa_metadata(&asset_id);
+    assert_eq!(stored.name, metadata.name);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #12)")]
+fn test_set_rwa_metadata_unregistered_asset_panics() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let oracle = create_rwa_oracle_contract(&e);
+    let asset_id = Symbol::new(&e, "UNREGISTERED");
+    let metadata = create_test_metadata(&e, asset_id.clone());
+    oracle.set_rwa_metadata(&asset_id, &metadata);
+}
+
 // ==================== Tokenization Info Tests ====================
 
 #[test]


### PR DESCRIPTION
Closes #30 

## Summary

The `set_rwa_metadata` function had a dead-code closure to check asset existence. The closure matched on both `Asset::Other` and `Asset::Stellar`, but since the asset is always constructed as `Asset::Other` at that point, the `Asset::Stellar` branch was unreachable and silently useless.

## Changes

- **`contract.rs`**: replaced the match-based closure with a direct `state.assets.contains(&asset)` call
- **`test/mod.rs`**: added `test_set_rwa_metadata_registered_asset_succeeds` and `test_set_rwa_metadata_unregistered_asset_panics`

All 66 tests pass and the WASM build is clean.