### PR TITLE
refactor(rwa-oracle): simplify get_all_rwa_assets using Map::keys()

### DIFF
--- a/stellar-contracts/rwa-oracle/src/contract.rs
+++ b/stellar-contracts/rwa-oracle/src/contract.rs
@@ -201,11 +201,7 @@ impl RWAOracle {
     /// Get all registered RWA asset IDs
     pub fn get_all_rwa_assets(env: &Env) -> Vec<Symbol> {
         let state = RWAOracleStorage::get(env);
-        let mut assets = Vec::new(env);
-        for (asset_id, _) in state.rwa_metadata.iter() {
-            assets.push_back(asset_id);
-        }
-        assets
+        state.rwa_metadata.keys()
     }
 
     /// Resolve a token contract address to its oracle asset identifier

--- a/stellar-contracts/rwa-oracle/src/test/mod.rs
+++ b/stellar-contracts/rwa-oracle/src/test/mod.rs
@@ -553,6 +553,35 @@ fn test_get_all_rwa_assets() {
     assert_eq!(all_assets.len(), 2);
 }
 
+// ==================== get_all_rwa_assets Tests ====================
+
+#[test]
+fn test_get_all_rwa_assets_empty() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let oracle = create_rwa_oracle_contract(&e);
+    let assets = oracle.get_all_rwa_assets();
+    assert_eq!(assets.len(), 0);
+}
+
+#[test]
+fn test_get_all_rwa_assets_returns_registered_ids() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let oracle = create_rwa_oracle_contract(&e);
+
+    let id_nvda = Symbol::new(&e, "NVDA");
+    let id_tsla = Symbol::new(&e, "TSLA");
+
+    oracle.set_rwa_metadata(&id_nvda, &create_test_metadata(&e, id_nvda.clone()));
+    oracle.set_rwa_metadata(&id_tsla, &create_test_metadata(&e, id_tsla.clone()));
+
+    let assets = oracle.get_all_rwa_assets();
+    assert_eq!(assets.len(), 2);
+    assert!(assets.contains(&id_nvda));
+    assert!(assets.contains(&id_tsla));
+}
+
 // ==================== SEP-40 Price Feed Tests ====================
 
 #[test]


### PR DESCRIPTION
Replace manual Vec-building loop with a single `state.rwa_metadata.keys()` call. Add unit tests for empty map and two-asset registration cases.

Closes #33 