### PR TITLE
feat: implement harvest swap path with Soroswap and slippage protection

### DIFF
--- a/stellar-contracts/adapters/adapter-aquarius/src/contract.rs
+++ b/stellar-contracts/adapters/adapter-aquarius/src/contract.rs
@@ -179,8 +179,8 @@ impl AquariusAdapter {
     ///
     /// pool.claim() is permissionless on-chain; guarded here to vault-only to keep
     /// reward accounting consistent with the vault's harvest_all() flow.
-    /// Returns the AQUA amount harvested (0 if no rewards have accrued).
-    pub fn a_harvest(env: Env, to: Address) -> i128 {
+    /// Returns the reward token address and amount harvested.
+    pub fn a_harvest(env: Env, to: Address) -> (Address, i128) {
         let storage = Storage::load(&env);
         // Only the configured vault can trigger harvests.
         storage.vault.require_auth();
@@ -192,6 +192,6 @@ impl AquariusAdapter {
             Events::harvested(&env, &adapter_addr, &storage.aqua_token, aqua_harvested);
         }
 
-        aqua_harvested
+        (storage.aqua_token.clone(), aqua_harvested)
     }
 }

--- a/stellar-contracts/adapters/adapter-aquarius/src/test/mod.rs
+++ b/stellar-contracts/adapters/adapter-aquarius/src/test/mod.rs
@@ -525,8 +525,9 @@ fn test_harvest_returns_zero_when_no_rewards() {
         .mint(&adapter.address, &amount);
     adapter.a_deposit(&amount, &vault);
 
-    // Mock pool always returns 0 rewards — a_harvest should return 0
-    let harvested = adapter.a_harvest(&vault);
+    // Mock pool always returns 0 rewards — a_harvest should return (aqua_token, 0)
+    let (reward_token, harvested) = adapter.a_harvest(&vault);
+    assert_eq!(reward_token, fixture.aqua_token.address);
     assert_eq!(harvested, 0i128);
 }
 

--- a/stellar-contracts/adapters/adapter-blend/src/blend_pool/mod.rs
+++ b/stellar-contracts/adapters/adapter-blend/src/blend_pool/mod.rs
@@ -1,6 +1,5 @@
 use soroban_sdk::{
     auth::{ContractContext, InvokerContractAuthEntry, SubContractInvocation},
-    token::TokenClient,
     vec, Address, Env, IntoVal,
 };
 
@@ -108,21 +107,15 @@ pub fn withdraw(env: &Env, amount: i128, to: &Address, storage: &AdapterStorage)
     actual_amount
 }
 
-/// Claim BLND emissions from the pool, transfer them to `to`, and return the amount claimed.
-pub fn claim(env: &Env, to: &Address, storage: &AdapterStorage) -> i128 {
+/// Claim BLND emissions from the pool directly to `to` (the vault), and return the token address and amount claimed.
+pub fn claim(env: &Env, to: &Address, storage: &AdapterStorage) -> (Address, i128) {
     let adapter_addr = env.current_contract_address();
     let pool = blend::PoolClient::new(env, &storage.blend_pool);
 
-    // Claim BLND emissions to the adapter first
-    let blnd_claimed = pool.claim(&adapter_addr, &storage.claim_ids, &adapter_addr);
+    // Claim BLND emissions directly to the vault (to)
+    let blnd_claimed = pool.claim(&adapter_addr, &storage.claim_ids, to);
 
-    if blnd_claimed > 0 {
-        // Forward BLND to vault (to)
-        let blnd_token = TokenClient::new(env, &storage.blend_token);
-        blnd_token.transfer(&adapter_addr, to, &blnd_claimed);
-    }
-
-    blnd_claimed
+    (storage.blend_token.clone(), blnd_claimed)
 }
 
 /// Returns the adapter's current position value in deposit_token units.

--- a/stellar-contracts/adapters/adapter-blend/src/contract.rs
+++ b/stellar-contracts/adapters/adapter-blend/src/contract.rs
@@ -101,25 +101,23 @@ impl BlendAdapter {
         0
     }
 
-    /// Claim BLND emissions from the pool and forward them to `to` (the vault).
+    /// Claim BLND emissions from the pool directly to `to` (the vault).
     ///
     /// Blend emits BLND tokens as liquidity mining rewards. This function:
-    ///   1. Claims BLND to the adapter via pool.claim()
-    ///   2. Transfers the BLND to the vault (`to`)
-    ///   3. Returns the BLND amount harvested
+    ///   1. Claims BLND directly to the vault via pool.claim()
+    ///   2. Returns the reward token address and amount harvested
     ///
-    /// The vault's neko-vault#harvest_all() accumulates this in liquid_reserve.
-    /// Swapping BLND → deposit_token is left to the vault manager.
-    pub fn a_harvest(env: Env, to: Address) -> i128 {
+    /// The vault's neko-vault#harvest_all() accumulates this or swaps it.
+    pub fn a_harvest(env: Env, to: Address) -> (Address, i128) {
         let storage = Storage::load(&env);
         let adapter_addr = env.current_contract_address();
 
-        let blnd_harvested = blend_pool::claim(&env, &to, &storage);
+        let (reward_token, blnd_harvested) = blend_pool::claim(&env, &to, &storage);
 
         if blnd_harvested > 0 {
             Events::harvested(&env, &adapter_addr, &storage.blend_token, blnd_harvested);
         }
 
-        blnd_harvested
+        (reward_token, blnd_harvested)
     }
 }

--- a/stellar-contracts/adapters/adapter-blend/src/test/mod.rs
+++ b/stellar-contracts/adapters/adapter-blend/src/test/mod.rs
@@ -357,3 +357,28 @@ fn test_adapter_apy_returns_zero() {
 
     assert_eq!(adapter.a_get_apy(), 0u32);
 }
+
+#[test]
+fn test_adapter_harvest() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let vault = Address::generate(&env);
+    let (deposit_token, _) = create_token(&env, &admin);
+
+    let fixture = create_blend_fixture(&env, &admin, &deposit_token.address);
+
+    let adapter = create_adapter(
+        &env,
+        &admin,
+        &vault,
+        &fixture.pool_addr,
+        &deposit_token.address,
+        &fixture.blnd_token.address,
+    );
+
+    let (reward_token, amount) = adapter.a_harvest(&vault);
+    assert_eq!(reward_token, fixture.blnd_token.address);
+    assert_eq!(amount, 0i128);
+}

--- a/stellar-contracts/adapters/adapter-neko/src/contract.rs
+++ b/stellar-contracts/adapters/adapter-neko/src/contract.rs
@@ -168,8 +168,9 @@ impl NekoAdapter {
     }
 
     /// No explicit harvest — yield is embedded in the b_rate appreciation.
-    pub fn a_harvest(_env: Env, _to: Address) -> i128 {
-        0
+    pub fn a_harvest(env: Env, _to: Address) -> (Address, i128) {
+        let storage = Storage::load(&env);
+        (storage.deposit_token, 0)
     }
 
     // ========== Helpers ==========

--- a/stellar-contracts/adapters/adapter-neko/src/test/mod.rs
+++ b/stellar-contracts/adapters/adapter-neko/src/test/mod.rs
@@ -207,6 +207,7 @@ fn test_adapter_apy_and_harvest() {
     // APY is 0 for now (placeholder)
     assert_eq!(adapter.a_get_apy(), 0u32);
 
-    // Harvest returns 0 (yield embedded in b_rate)
-    assert_eq!(adapter.a_harvest(&vault), 0i128);
+    let (reward_token, amount) = adapter.a_harvest(&vault);
+    assert_eq!(reward_token, token.address);
+    assert_eq!(amount, 0i128);
 }

--- a/stellar-contracts/adapters/adapter-soroswap/src/contract.rs
+++ b/stellar-contracts/adapters/adapter-soroswap/src/contract.rs
@@ -111,7 +111,8 @@ impl SoroswapAdapter {
 
     /// No explicit harvest — Soroswap fees accrue into the pair reserves and are
     /// realized automatically when liquidity is removed.
-    pub fn a_harvest(_env: Env, _to: Address) -> i128 {
-        0
+    pub fn a_harvest(env: Env, _to: Address) -> (Address, i128) {
+        let storage = Storage::load(&env);
+        (storage.token_a, 0)
     }
 }

--- a/stellar-contracts/adapters/adapter-soroswap/src/test/mod.rs
+++ b/stellar-contracts/adapters/adapter-soroswap/src/test/mod.rs
@@ -267,5 +267,7 @@ fn test_adapter_harvest_returns_zero() {
         &fixture.token_b.address,
     );
 
-    assert_eq!(adapter.a_harvest(&vault), 0i128);
+    let (reward_token, amount) = adapter.a_harvest(&vault);
+    assert_eq!(reward_token, fixture.token_a.address);
+    assert_eq!(amount, 0i128);
 }

--- a/stellar-contracts/neko-vault/src/adapters/mod.rs
+++ b/stellar-contracts/neko-vault/src/adapters/mod.rs
@@ -24,6 +24,6 @@ pub trait IAdapter {
     fn a_get_apy(env: Env) -> u32;
 
     /// Harvest accumulated rewards and send them to `to` (vault).
-    /// Returns the amount harvested (0 if yield is embedded in position rate).
-    fn a_harvest(env: Env, to: Address) -> i128;
+    /// Returns the reward token address and the amount harvested.
+    fn a_harvest(env: Env, to: Address) -> (Address, i128);
 }

--- a/stellar-contracts/neko-vault/src/common/events.rs
+++ b/stellar-contracts/neko-vault/src/common/events.rs
@@ -39,6 +39,13 @@ pub struct ProtocolRemovedEvent {
     pub id: Symbol,
 }
 
+#[contractevent]
+pub struct DustAccumulatedEvent {
+    pub adapter: Address,
+    pub token: Address,
+    pub amount: i128,
+}
+
 // ============================================================================
 // SEP-41 token events (matching neko-token pattern)
 // ============================================================================
@@ -112,6 +119,15 @@ impl Events {
 
     pub fn protocol_removed(env: &Env, id: &Symbol) {
         ProtocolRemovedEvent { id: id.clone() }.publish(env);
+    }
+
+    pub fn dust_accumulated(env: &Env, adapter: &Address, token: &Address, amount: i128) {
+        DustAccumulatedEvent {
+            adapter: adapter.clone(),
+            token: token.clone(),
+            amount,
+        }
+        .publish(env);
     }
 
     pub fn transfer(env: &Env, from: &Address, to: &Address, amount: i128) {

--- a/stellar-contracts/neko-vault/src/common/storage.rs
+++ b/stellar-contracts/neko-vault/src/common/storage.rs
@@ -1,8 +1,8 @@
-use soroban_sdk::{Address, Env, panic_with_error};
+use soroban_sdk::{Address, Env, panic_with_error, symbol_short};
 
 use crate::common::error::Error;
 use crate::common::types::{
-    DataKey, INSTANCE_BUMP, INSTANCE_TTL, STORAGE_KEY, Txn, VaultAllowance, VaultStorage,
+    DataKey, INSTANCE_BUMP, INSTANCE_TTL, STORAGE_KEY, Txn, VaultAllowance, VaultStorage, HarvestConfig,
 };
 
 // ============================================================================
@@ -28,6 +28,21 @@ impl Storage {
 
     pub fn is_initialized(env: &Env) -> bool {
         env.storage().instance().has(&STORAGE_KEY)
+    }
+
+    pub fn get_harvest_config(env: &Env) -> Option<HarvestConfig> {
+        env.storage()
+            .instance()
+            .get(&symbol_short!("H_CONF"))
+    }
+
+    pub fn set_harvest_config(env: &Env, config: &HarvestConfig) {
+        env.storage()
+            .instance()
+            .set(&symbol_short!("H_CONF"), config);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_TTL, INSTANCE_BUMP);
     }
 }
 

--- a/stellar-contracts/neko-vault/src/common/types.rs
+++ b/stellar-contracts/neko-vault/src/common/types.rs
@@ -60,6 +60,15 @@ pub struct VaultConfig {
 }
 
 #[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HarvestConfig {
+    pub reward_token: Address,
+    pub swap_router: Address,
+    pub min_swap_amount: i128,
+    pub max_slippage_bps: u32,
+}
+
+#[contracttype]
 #[derive(Clone, Debug)]
 pub struct ProtocolAllocation {
     /// Adapter contract address

--- a/stellar-contracts/neko-vault/src/contract.rs
+++ b/stellar-contracts/neko-vault/src/contract.rs
@@ -4,7 +4,7 @@ use crate::admin::Admin;
 use crate::common::error::Error;
 use crate::common::events::Events;
 use crate::common::storage::{AllowanceStorage, BalanceStorage, Storage};
-use crate::common::types::{ProtocolAllocation, RiskTier, VaultConfig, VaultStatus};
+use crate::common::types::{ProtocolAllocation, RiskTier, VaultConfig, VaultStatus, HarvestConfig};
 use crate::strategies::harvester::Harvester;
 use crate::strategies::optimizer::Optimizer;
 use crate::strategies::rebalancer::Rebalancer;
@@ -65,6 +65,16 @@ impl VaultContract {
 
     pub fn set_manager(env: Env, manager: Address) {
         Admin::set_manager(&env, &manager);
+    }
+
+    pub fn set_harvest_config(env: Env, config: HarvestConfig) {
+        Admin::require_admin(&env);
+        Storage::set_harvest_config(&env, &config);
+    }
+
+    pub fn get_harvest_config(env: Env) -> Option<HarvestConfig> {
+        Admin::require_admin(&env);
+        Storage::get_harvest_config(&env)
     }
 
     // ========== Protocol management ==========

--- a/stellar-contracts/neko-vault/src/strategies/harvester.rs
+++ b/stellar-contracts/neko-vault/src/strategies/harvester.rs
@@ -1,4 +1,9 @@
-use soroban_sdk::Env;
+use soroban_sdk::{Env, IntoVal};
+
+pub mod soroswap_router {
+    soroban_sdk::contractimport!(file = "../wasms/external_wasms/soroswap/router.wasm");
+    pub type RouterClient<'a> = Client<'a>;
+}
 
 use crate::adapters::AdapterClient;
 use crate::common::error::Error;
@@ -18,16 +23,102 @@ impl Harvester {
         let vault_addr = env.current_contract_address();
         let mut total_harvested = 0i128;
 
+        let harvest_config = Storage::get_harvest_config(env);
+
         for protocol_id in storage.protocol_ids.iter() {
-            if let Some(alloc) = storage.protocol_allocations.get(protocol_id) {
+            if let Some(alloc) = storage.protocol_allocations.get(protocol_id.clone()) {
                 if !alloc.is_active {
                     continue;
                 }
                 let adapter = AdapterClient::new(env, &alloc.adapter);
-                let harvested = adapter.a_harvest(&vault_addr);
-                total_harvested = total_harvested
-                    .checked_add(harvested)
-                    .ok_or(Error::ArithmeticError)?;
+                let (reward_token, amount) = adapter.a_harvest(&vault_addr);
+                if amount <= 0 {
+                    continue;
+                }
+
+                if reward_token == storage.deposit_token {
+                    total_harvested = total_harvested
+                        .checked_add(amount)
+                        .ok_or(Error::ArithmeticError)?;
+                } else {
+                    let config = harvest_config.as_ref().ok_or(Error::InvalidConfig)?;
+                    if reward_token != config.reward_token {
+                        return Err(Error::InvalidConfig);
+                    }
+
+                    if amount >= config.min_swap_amount {
+                        let router = soroswap_router::RouterClient::new(env, &config.swap_router);
+                        let path = soroban_sdk::vec![env, reward_token.clone(), storage.deposit_token.clone()];
+
+                        // 1. Estimate expected output via router_get_amounts_out
+                        let estimate_args = soroban_sdk::vec![
+                            env,
+                            amount.into_val(env),
+                            path.clone().into_val(env),
+                        ];
+                        let estimate_res = env.try_invoke_contract::<soroban_sdk::Vec<i128>, soroban_sdk::Error>(
+                            &config.swap_router,
+                            &soroban_sdk::Symbol::new(env, "router_get_amounts_out"),
+                            estimate_args,
+                        );
+
+                        if let Ok(Ok(amounts_out)) = estimate_res {
+                            let expected_out = amounts_out.last().unwrap_or(0);
+                            let min_amount_out = expected_out
+                                .checked_mul(10000 - config.max_slippage_bps as i128)
+                                .ok_or(Error::ArithmeticError)?
+                                .checked_div(10000)
+                                .ok_or(Error::ArithmeticError)?;
+
+                            // Resolve the pair address
+                            let pair = router.router_pair_for(&reward_token, &storage.deposit_token);
+
+                            // Pre-authorize the router to transfer reward tokens from the vault to the pair
+                            env.authorize_as_current_contract(soroban_sdk::vec![
+                                env,
+                                soroban_sdk::auth::InvokerContractAuthEntry::Contract(soroban_sdk::auth::SubContractInvocation {
+                                    context: soroban_sdk::auth::ContractContext {
+                                        contract: reward_token.clone(),
+                                        fn_name: soroban_sdk::Symbol::new(env, "transfer"),
+                                        args: soroban_sdk::vec![
+                                            env,
+                                            vault_addr.clone().into_val(env),
+                                            pair.clone().into_val(env),
+                                            amount.into_val(env),
+                                        ],
+                                    },
+                                    sub_invocations: soroban_sdk::vec![env],
+                                }),
+                            ]);
+
+                            let deadline = env.ledger().timestamp() + 3600;
+                            let swap_args = soroban_sdk::vec![
+                                env,
+                                amount.into_val(env),
+                                min_amount_out.into_val(env),
+                                path.into_val(env),
+                                vault_addr.clone().into_val(env),
+                                deadline.into_val(env),
+                            ];
+
+                            let swap_res = env.try_invoke_contract::<soroban_sdk::Vec<i128>, soroban_sdk::Error>(
+                                &config.swap_router,
+                                &soroban_sdk::Symbol::new(env, "swap_exact_tokens_for_tokens"),
+                                swap_args,
+                            );
+
+                            if let Ok(Ok(swap_out)) = swap_res {
+                                let actual_out = swap_out.last().unwrap_or(0);
+                                total_harvested = total_harvested
+                                    .checked_add(actual_out)
+                                    .ok_or(Error::ArithmeticError)?;
+                            }
+                        }
+                    } else {
+                        // Skip swap below min_swap_amount (dust guard)
+                        Events::dust_accumulated(env, &alloc.adapter, &reward_token, amount);
+                    }
+                }
             }
         }
 

--- a/stellar-contracts/neko-vault/src/test/mod.rs
+++ b/stellar-contracts/neko-vault/src/test/mod.rs
@@ -6,7 +6,7 @@ use soroban_sdk::{
     token::{StellarAssetClient, TokenClient},
 };
 
-use crate::common::types::{RiskTier, VaultConfig, VaultStatus};
+use crate::common::types::{RiskTier, VaultConfig, VaultStatus, HarvestConfig};
 use crate::{VaultContract, VaultContractClient};
 
 // ============================================================================
@@ -74,8 +74,34 @@ impl MockAdapter {
         500 // 5% in BPS
     }
 
-    pub fn a_harvest(_env: Env, _to: Address) -> i128 {
-        0 // No explicit harvest; yield embedded in b_rate
+    pub fn a_harvest(env: Env, to: Address) -> (Address, i128) {
+        let reward_token: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("H_TOK"))
+            .unwrap_or_else(|| {
+                env.storage()
+                    .instance()
+                    .get(&symbol_short!("TOKEN"))
+                    .unwrap()
+            });
+        let reward_amount: i128 = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("H_AMT"))
+            .unwrap_or(0);
+
+        if reward_amount > 0 {
+            let token = TokenClient::new(&env, &reward_token);
+            token.transfer(&env.current_contract_address(), &to, &reward_amount);
+        }
+
+        (reward_token, reward_amount)
+    }
+
+    pub fn set_mock_harvest(env: Env, token: Address, amount: i128) {
+        env.storage().instance().set(&symbol_short!("H_TOK"), &token);
+        env.storage().instance().set(&symbol_short!("H_AMT"), &amount);
     }
 }
 
@@ -380,4 +406,234 @@ fn test_decimals_name_symbol() {
     assert_eq!(vault.decimals(), 7u32);
     assert_eq!(vault.name(), String::from_str(&env, "Neko CETES Vault"));
     assert_eq!(vault.symbol(), String::from_str(&env, "vCETES"));
+}
+
+// ============================================================================
+// Mock Router Contract
+// ============================================================================
+
+#[contract]
+struct MockRouter;
+
+#[contractimpl]
+impl MockRouter {
+    pub fn router_pair_for(env: Env, _token_a: Address, _token_b: Address) -> Address {
+        let key = symbol_short!("PAIR");
+        env.storage().instance().get(&key).unwrap_or_else(|| {
+            Address::generate(&env)
+        })
+    }
+
+    pub fn set_pair(env: Env, pair: Address) {
+        env.storage().instance().set(&symbol_short!("PAIR"), &pair);
+    }
+
+    pub fn router_get_amounts_out(env: Env, amount_in: i128, _path: soroban_sdk::Vec<soroban_sdk::Address>) -> soroban_sdk::Vec<i128> {
+        let rate = env.storage().instance().get(&symbol_short!("E_RATE"))
+            .unwrap_or_else(|| env.storage().instance().get(&symbol_short!("RATE")).unwrap_or(100i128));
+        let amount_out = amount_in * rate / 100;
+        soroban_sdk::vec![&env, amount_in, amount_out]
+    }
+
+    pub fn set_rate(env: Env, rate: i128) {
+        env.storage().instance().set(&symbol_short!("RATE"), &rate);
+    }
+
+    pub fn set_rates(env: Env, estimate_rate: i128, swap_rate: i128) {
+        env.storage().instance().set(&symbol_short!("E_RATE"), &estimate_rate);
+        env.storage().instance().set(&symbol_short!("S_RATE"), &swap_rate);
+    }
+
+    pub fn swap_exact_tokens_for_tokens(
+        env: Env,
+        amount_in: i128,
+        amount_out_min: i128,
+        path: soroban_sdk::Vec<soroban_sdk::Address>,
+        to: Address,
+        _deadline: u64,
+    ) -> soroban_sdk::Vec<i128> {
+        let token_in_addr = path.get(0).unwrap();
+        let token_out_addr = path.get(1).unwrap();
+        
+        let rate = env.storage().instance().get(&symbol_short!("S_RATE"))
+            .unwrap_or_else(|| env.storage().instance().get(&symbol_short!("RATE")).unwrap_or(100i128));
+        let amount_out = amount_in * rate / 100;
+        
+        if amount_out < amount_out_min {
+            soroban_sdk::panic_with_error!(&env, crate::common::error::Error::ArithmeticError);
+        }
+
+        let pair = Self::router_pair_for(env.clone(), token_in_addr.clone(), token_out_addr.clone());
+        let token_in = TokenClient::new(&env, &token_in_addr);
+        token_in.transfer(&to, &pair, &amount_in);
+
+        let token_out = TokenClient::new(&env, &token_out_addr);
+        token_out.transfer(&env.current_contract_address(), &to, &amount_out);
+
+        soroban_sdk::vec![&env, amount_in, amount_out]
+    }
+}
+
+// ============================================================================
+// Harvest Swap Path Tests
+// ============================================================================
+
+#[test]
+fn test_harvest_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (token, _) = create_token(&env, &admin);
+    let vault = create_vault(&env, &admin, &token.address);
+
+    let adapter_id = env.register(MockAdapter, ());
+    MockAdapterClient::new(&env, &adapter_id).initialize(&token.address, &vault.address);
+    vault.add_protocol(&symbol_short!("MOCK"), &adapter_id, &10000u32, &RiskTier::Low);
+
+    let harvested = vault.harvest_all();
+    assert_eq!(harvested, 0);
+    assert_eq!(vault.get_liquid_reserve(), 0);
+}
+
+#[test]
+fn test_harvest_same_token() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (token, token_admin) = create_token(&env, &admin);
+    let vault = create_vault(&env, &admin, &token.address);
+
+    let adapter_id = env.register(MockAdapter, ());
+    let adapter = MockAdapterClient::new(&env, &adapter_id);
+    adapter.initialize(&token.address, &vault.address);
+    vault.add_protocol(&symbol_short!("MOCK"), &adapter_id, &10000u32, &RiskTier::Low);
+
+    let reward_amount = 50_0000000i128;
+    token_admin.mint(&adapter_id, &reward_amount);
+    adapter.set_mock_harvest(&token.address, &reward_amount);
+
+    let harvested = vault.harvest_all();
+    assert_eq!(harvested, reward_amount);
+    assert_eq!(vault.get_liquid_reserve(), reward_amount);
+}
+
+#[test]
+fn test_harvest_swap_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (deposit_token, deposit_admin) = create_token(&env, &admin);
+    let (reward_token, reward_admin) = create_token(&env, &admin);
+    let vault = create_vault(&env, &admin, &deposit_token.address);
+
+    let adapter_id = env.register(MockAdapter, ());
+    let adapter = MockAdapterClient::new(&env, &adapter_id);
+    adapter.initialize(&deposit_token.address, &vault.address);
+    vault.add_protocol(&symbol_short!("MOCK"), &adapter_id, &10000u32, &RiskTier::Low);
+
+    let router_id = env.register(MockRouter, ());
+    let router = MockRouterClient::new(&env, &router_id);
+    let pair = Address::generate(&env);
+    router.set_pair(&pair);
+    router.set_rate(&90);
+
+    deposit_admin.mint(&router_id, &1000_0000000i128);
+
+    let config = HarvestConfig {
+        reward_token: reward_token.address.clone(),
+        swap_router: router_id.clone(),
+        min_swap_amount: 10_0000000i128,
+        max_slippage_bps: 1000,
+    };
+    vault.set_harvest_config(&config);
+
+    let reward_amount = 100_0000000i128;
+    reward_admin.mint(&adapter_id, &reward_amount);
+    adapter.set_mock_harvest(&reward_token.address, &reward_amount);
+
+    let harvested = vault.harvest_all();
+    assert_eq!(harvested, 90_0000000i128);
+    assert_eq!(vault.get_liquid_reserve(), 90_0000000i128);
+}
+
+#[test]
+fn test_harvest_swap_dust_skipped() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (deposit_token, _) = create_token(&env, &admin);
+    let (reward_token, reward_admin) = create_token(&env, &admin);
+    let vault = create_vault(&env, &admin, &deposit_token.address);
+
+    let adapter_id = env.register(MockAdapter, ());
+    let adapter = MockAdapterClient::new(&env, &adapter_id);
+    adapter.initialize(&deposit_token.address, &vault.address);
+    vault.add_protocol(&symbol_short!("MOCK"), &adapter_id, &10000u32, &RiskTier::Low);
+
+    let router_id = env.register(MockRouter, ());
+    let router = MockRouterClient::new(&env, &router_id);
+    let pair = Address::generate(&env);
+    router.set_pair(&pair);
+
+    let config = HarvestConfig {
+        reward_token: reward_token.address.clone(),
+        swap_router: router_id.clone(),
+        min_swap_amount: 10_0000000i128,
+        max_slippage_bps: 1000,
+    };
+    vault.set_harvest_config(&config);
+
+    let reward_amount = 5_0000000i128;
+    reward_admin.mint(&adapter_id, &reward_amount);
+    adapter.set_mock_harvest(&reward_token.address, &reward_amount);
+
+    let harvested = vault.harvest_all();
+    assert_eq!(harvested, 0);
+    assert_eq!(vault.get_liquid_reserve(), 0);
+
+    assert_eq!(reward_token.balance(&vault.address), reward_amount);
+}
+
+#[test]
+fn test_harvest_swap_slippage_rejection() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (deposit_token, deposit_admin) = create_token(&env, &admin);
+    let (reward_token, reward_admin) = create_token(&env, &admin);
+    let vault = create_vault(&env, &admin, &deposit_token.address);
+
+    let adapter_id = env.register(MockAdapter, ());
+    let adapter = MockAdapterClient::new(&env, &adapter_id);
+    adapter.initialize(&deposit_token.address, &vault.address);
+    vault.add_protocol(&symbol_short!("MOCK"), &adapter_id, &10000u32, &RiskTier::Low);
+
+    let router_id = env.register(MockRouter, ());
+    let router = MockRouterClient::new(&env, &router_id);
+    let pair = Address::generate(&env);
+    router.set_pair(&pair);
+    router.set_rates(&100, &80);
+
+    deposit_admin.mint(&router_id, &1000_0000000i128);
+
+    let config = HarvestConfig {
+        reward_token: reward_token.address.clone(),
+        swap_router: router_id.clone(),
+        min_swap_amount: 10_0000000i128,
+        max_slippage_bps: 500,
+    };
+    vault.set_harvest_config(&config);
+
+    let reward_amount = 100_0000000i128;
+    reward_admin.mint(&adapter_id, &reward_amount);
+    adapter.set_mock_harvest(&reward_token.address, &reward_amount);
+
+    let harvested = vault.harvest_all();
+    assert_eq!(harvested, 0);
+    assert_eq!(vault.get_liquid_reserve(), 0);
 }


### PR DESCRIPTION
# PR Description: Harvest Swap Path with Soroswap & Slippage Protection

## Problem
In `neko-vault`, calling `harvest_all` previously added whatever the adapters' `a_harvest` returned directly to the `liquid_reserve`. For the Blend Adapter, it claimed raw `BLND` tokens and forwarded them directly to the vault. This caused two main issues:
1. **NAV Inflation**: Raw reward tokens (like `BLND` or `AQUA`) were counted 1:1 with the deposit token, artificially inflating the vault's share price.
2. **Stranded Rewards**: Rewards were never swapped, accumulating in the vault contract without being usable for withdrawals or rebalancing.

## Solution
This PR implements a harvest swap path. When rewards differ from the deposit token, the vault retrieves them, checks if they exceed a configured dust limit, queries Soroswap for a price estimate, and swaps them to the deposit token with strict slippage enforcement.

### Key Changes
1. **`HarvestConfig` Struct & Storage**:
   - Added configuration state in instance storage containing `reward_token`, `swap_router` address, `min_swap_amount` (dust guard), and `max_slippage_bps`.
   - Exposed `set_harvest_config` and `get_harvest_config` admin functions (admin authorization required).
2. **Polymorphic `IAdapter` Interface**:
   - Updated `a_harvest` to return `(Address, i128)` (reward token address and amount) to support multi-token rewards cleanly.
   - Refactored `adapter-blend`, `adapter-aquarius`, `adapter-neko`, and `adapter-soroswap` to implement the new signature.
   - Optimized `adapter-blend` to claim rewards directly to the vault recipient using the target parameter in the Blend pool `claim` API, eliminating internal adapter token transfers.
3. **Vault Harvester Rewrite**:
   - Modified `harvest_all` to execute swaps via Soroswap if the reward token differs from the deposit token and exceeds the `min_swap_amount`.
   - Utilizes `router_get_amounts_out` for spot price estimation and sets the required `min_amount_out` according to slippage rules.
   - Wraps the swap execution in `try_invoke_contract` so that any swap reverts (e.g., due to slippage) skip the adapter gracefully without failing the entire harvest process.
   - Skips swap for amounts under `min_swap_amount` (dust guard) and emits a `DustAccumulated` event.
4. **Testing & Verification**:
   - Updated mock adapter and mock pool test setups to match the updated signature.
   - Added a `MockRouter` contract in `neko-vault` tests to simulate estimation and swaps.
   - Added 5 new integration tests verifying same-token reward accumulation, zero rewards, successful swaps, dust-skipping, and slippage rejection.

## Verification & Testing Results
All workspace unit and integration tests compile cleanly and pass successfully:
- `cargo test --package neko-vault` -> **Passed** (17 tests)
- `cargo test --package adapter-blend` -> **Passed** (6 tests)
- `cargo test --package adapter-aquarius` -> **Passed** (16 tests)
- `cargo test --package adapter-neko` -> **Passed** (5 tests)
- `cargo test --package adapter-soroswap` -> **Passed** (6 tests)

Closes #48